### PR TITLE
Bug fix for withSystemRandom

### DIFF
--- a/System/Random/MWC.hs
+++ b/System/Random/MWC.hs
@@ -96,9 +96,6 @@ class M.Unbox a => Variate a where
     --   statistical calculations that require non-zero values
     --   (e.g. uses of the 'log' function).
     --
-    -- * The range of random 'Integer' variates is the same as for
-    --   'Int'.
-    --
     -- To generate a 'Float' variate with a range of [0,1), subtract
     -- 2**(-33).  To do the same with 'Double' variates, subtract
     -- 2**(-53).


### PR DESCRIPTION
Here is fix for nasty bug in withSystemRandom. If action passed by user throws IO exception this exception will be catched and action will be executed second time with seed  initialized from system time. Fix is to catch exceptions only during seed acquisition

here is test case: https://gist.github.com/1144855

Also small documentation updates
