### PR TITLE
Remove old workarounds

### DIFF
--- a/mwc-random.cabal
+++ b/mwc-random.cabal
@@ -37,7 +37,7 @@ library
     base < 5,
     primitive,
     time,
-    vector >= 0.6.0.2
+    vector >= 0.7
   if impl(ghc >= 6.10)
     build-depends:
       base >= 4


### PR DESCRIPTION
mwc-random contain several workarounds for deficiencies in vector library. Those were fixed in 0.7 release. I think it makes sense to remove those workaround and bump dependency on vector to 0.7.
