### PR TITLE
Unbreak 'cabal configure --enable-tests'.

### DIFF
--- a/mwc-random.cabal
+++ b/mwc-random.cabal
@@ -55,18 +55,17 @@ library
     ghc-options: -fwarn-tabs
 
 test-suite tests
-  buildable:      False
   type:           exitcode-stdio-1.0
   hs-source-dirs: test
   main-is:        tests.hs
   other-modules:  KS
                   QC
-                  Uniform
 
   ghc-options:
     -Wall -threaded -rtsopts
 
   build-depends:
+    vector >= 0.7,
     HUnit,
     QuickCheck,
     base,


### PR DESCRIPTION
Signed-off-by: Sergei Trofimovich slyfox@gentoo.org
