### PR TITLE
createSystemRandom

### DIFF
--- a/System/Random/MWC.hs
+++ b/System/Random/MWC.hs
@@ -69,6 +69,7 @@ module System.Random.MWC
     , create
     , initialize
     , withSystemRandom
+    , createSystemRandom
 
     -- ** Type helpers
     -- $typehelp
@@ -440,6 +441,11 @@ withSystemRandom act = do
   where
     warned = unsafePerformIO $ newIORef False
     {-# NOINLINE warned #-}
+
+-- | Seed a PRNG with data from the system's fast source of pseudo-random
+-- numbers. All the caveats of 'withSystemRandom' apply here as well.
+createSystemRandom :: IO GenIO
+createSystemRandom = withSystemRandom (return :: GenIO -> IO GenIO)
 
 -- | Compute the next index into the state pool.  This is simply
 -- addition modulo 256.


### PR DESCRIPTION
The use case for this is when it's inconvenient to have to restructure your code to live inside `withSystemRandom`. I original wrote the attached implementation in my own code and then created this pull request. However, once I looked at the code for `withSystemRandom`, it looks like it would be safe to reimplement `createSystemRandom` as:

``` haskell
createSystemRandom :: IO GenIO
createSystemRandom = withSystemRandom (return :: GenIO -> IO GenIO)
```

If my understanding is correct, I can update this pull request to use that implementation instead.
