### PR TITLE
Benchmarks and performance improvements for binomial

### DIFF
--- a/System/Random/MWC/Distributions.hs
+++ b/System/Random/MWC/Distributions.hs
@@ -394,7 +394,7 @@ binomialTPE n p g = loop
     -- Acceptance / rejection comparison
     step5 :: Int -> Double -> m Int
     step5 !ix !v
-      | var <= accept = return $! if p > 0 then ix else n - ix
+      | var <= accept = return ix
       | otherwise     = loop
       where
         var    = log v

--- a/System/Random/MWC/Distributions.hs
+++ b/System/Random/MWC/Distributions.hs
@@ -385,77 +385,74 @@ binomial nTrials prob gen
 binomialTPE :: forall g m . StatefulGen g m => Int -> Double -> g -> m Int
 {-# INLINE binomialTPE #-}
 binomialTPE n p g =
-  let q    = 1 - p
-      np   = fromIntegral n * p
-      ffm  = np + p
-      bigM = floor ffm
-      -- Half integer mean (tip of triangle)
-      xm   = fromIntegral bigM + 0.5
-      npq  = np * q
-
-      -- p1: the distance to the left and right edges of the triangle
-      -- region below the target distribution; since height=1, also:
-      -- area of region (half base * height)
-      p1 = fromIntegral (floor (2.195 * sqrt npq - 4.6 * q) :: Int) + 0.5
-      -- Left edge of triangle
-      xl = xm - p1
-      -- Right edge of triangle
-      xr = xm + p1
-      c  = 0.134 + 20.5 / (15.3 + fromIntegral bigM)
-      -- p1 + area of parallelogram region
-      p2 = p1 * (1.0 + c + c)
-      al = (ffm - xl) / (ffm - xl * p)
-      lambdaL = al * (1.0 + 0.5 * al)
-      ar = (xr - ffm) / (xr * q)
-      lambdaR = ar * (1.0 + 0.5 * ar)
-
-      -- p2 + area of left tail
-      p3 = p2 + c / lambdaL
-      -- p3 + area of right tail
-      p4 = p3 + c / lambdaR
-
-      -- Acceptance / rejection comparison
+  let -- Acceptance / rejection comparison
       step5 :: Int -> Double -> m Int
       step5 ix v
-        | var <= accept = return $ if p > 0 then ix else n - ix
-        | otherwise     = hh
+        | var <= accept = return $! if p > 0 then ix else n - ix
+        | otherwise     = loop
         where
           var = log v
           accept = logFactorial bigM + logFactorial (n - bigM) -
                    logFactorial ix - logFactorial (n - ix) +
                    fromIntegral (ix - bigM) * log (p / q)
 
-      h :: Double -> Double -> m Int
-      h u v | -- Triangular region
-              u <= p1 = return $ floor $ xm - p1 * v + u
+      selectArea :: Double -> Double -> m Int
+      selectArea u v
+          -- Triangular region
+        | u <= p1 = return $! floor $ xm - p1 * v + u
+          -- Parallelogram region
+        | u <= p2 = do let x = xl + (u - p1) / c
+                           w = v * c + 1.0 - abs (x - xm) / p1
+                       if w > 1 || w <= 0
+                         then loop
+                         else do let ix = floor x
+                                 step5 ix w
+          -- Left tail
+        | u <= p3 = case floor $ xl + log v / lambdaL of
+            ix | ix < 0    -> loop
+               | otherwise -> do let w = v * (u - p2) * lambdaL
+                                 step5 ix w
+          -- Right tail
+        | otherwise = case floor $ xr - log v / lambdaR of
+            ix | ix > n    -> loop
+               | otherwise -> do let w = v * (u - p3) * lambdaR
+                                 step5 ix w
 
-              -- Parallelogram region
-            | u <= p2 = do let x = xl + (u - p1) / c
-                               w = v * c + 1.0 - abs (x - xm) / p1
-                           if w > 1 || w <= 0
-                            then hh
-                            else do let ix = floor x
-                                    step5 ix w
-
-              -- Left tail
-            | u <= p3 = do let ix = floor $ xl + log v / lambdaL
-                           if ix < 0
-                             then hh
-                             else do let w = v * (u - p2) * lambdaL
-                                     step5 ix w
-
-              -- Right tail
-            | otherwise = do let ix = floor $ xr - log v / lambdaR
-                             if ix > n
-                               then hh
-                               else do let w = v * (u - p3) * lambdaR
-                                       step5 ix w
-
-      hh = do
+      loop = do
         u <- uniformRM (0.0, p4) g
         v <- uniformDoublePositive01M g
-        h u v
-  in hh
+        selectArea u v
+  in loop
+  where
+    q    = 1 - p
+    np   = fromIntegral n * p
+    ffm  = np + p
+    bigM = floor ffm
+    -- Half integer mean (tip of triangle)
+    xm   = fromIntegral bigM + 0.5
+    npq  = np * q
+
+    -- p1: the distance to the left and right edges of the triangle
+    -- region below the target distribution; since height=1, also:
+    -- area of region (half base * height)
+    p1 = fromIntegral (floor (2.195 * sqrt npq - 4.6 * q) :: Int) + 0.5
+    -- Left edge of triangle
+    xl = xm - p1
+    -- Right edge of triangle
+    xr = xm + p1
+    c  = 0.134 + 20.5 / (15.3 + fromIntegral bigM)
+    -- p1 + area of parallelogram region
+    p2 = p1 * (1.0 + c + c)
+    al = (ffm - xl) / (ffm - xl * p)
+    lambdaL = al * (1.0 + 0.5 * al)
+    ar = (xr - ffm) / (xr * q)
+    lambdaR = ar * (1.0 + 0.5 * ar)
+
+    -- p2 + area of left tail
+    p3 = p2 + c / lambdaL
+    -- p3 + area of right tail
+    p4 = p3 + c / lambdaR
+
 
 binomialInv :: StatefulGen g m => Int -> Double -> g -> m Int
 {-# INLINE binomialInv #-}

--- a/System/Random/MWC/Distributions.hs
+++ b/System/Random/MWC/Distributions.hs
@@ -347,23 +347,6 @@ pkgError :: String -> String -> a
 pkgError func msg = error $ "System.Random.MWC.Distributions." ++ func ++
                             ": " ++ msg
 
--- $references
---
--- * Doornik, J.A. (2005) An improved ziggurat method to generate
---   normal random samples. Mimeo, Nuffield College, University of
---   Oxford.  <http://www.doornik.com/research/ziggurat.pdf>
---
--- * Thomas, D.B.; Leong, P.G.W.; Luk, W.; Villasenor, J.D.
---   (2007). Gaussian random number generators.
---   /ACM Computing Surveys/ 39(4).
---   <http://www.cse.cuhk.edu.hk/~phwl/mt/public/archives/papers/grng_acmcs07.pdf>
---
--- * Kachitvichyanukul, V. and Schmeiser, B. W.  Binomial Random
---   Variate Generation.  Communications of the ACM, 31, 2 (February,
---   1988) 216. <https://dl.acm.org/doi/pdf/10.1145/42372.42381>
---   Here's an example of how the algorithm's sampling regions look
---   ![Something](docs/RecreateFigure.svg)
-
 -- | Random variate generator for Binomial distribution
 --
 -- The probability of getting exactly k successes in n trials is
@@ -488,3 +471,21 @@ binomialInv n p g = do
           rNew = rPrev * ((a / fromIntegral xNew) - s)
   u <- uniformDoublePositive01M g
   let (_, _, x) = until (\(t, v, _) -> v <= t) f (r, u, 0) in return x
+
+
+-- $references
+--
+-- * Doornik, J.A. (2005) An improved ziggurat method to generate
+--   normal random samples. Mimeo, Nuffield College, University of
+--   Oxford.  <http://www.doornik.com/research/ziggurat.pdf>
+--
+-- * Thomas, D.B.; Leong, P.G.W.; Luk, W.; Villasenor, J.D.
+--   (2007). Gaussian random number generators.
+--   /ACM Computing Surveys/ 39(4).
+--   <http://www.cse.cuhk.edu.hk/~phwl/mt/public/archives/papers/grng_acmcs07.pdf>
+--
+-- * Kachitvichyanukul, V. and Schmeiser, B. W.  Binomial Random
+--   Variate Generation.  Communications of the ACM, 31, 2 (February,
+--   1988) 216. <https://dl.acm.org/doi/pdf/10.1145/42372.42381>
+--   Here's an example of how the algorithm's sampling regions look
+--   ![Something](docs/RecreateFigure.svg)

--- a/System/Random/MWC/Distributions.hs
+++ b/System/Random/MWC/Distributions.hs
@@ -472,9 +472,11 @@ invertBinomial
   -> Int
 invertBinomial !n !p !u0 = invert (q^n) u0 0
   where
-    q = 1 - p
-    s = p / q
-    a = fromIntegral (n + 1) * s
+    -- We forcing s&a in order to avoid allocating thunks. Those are
+    -- relatively expensive
+    q  = 1 - p
+    !s = p / q
+    !a = fromIntegral (n + 1) * s
     --
     invert !r !u !x
       | u <= r    = x

--- a/bench/Benchmark.hs
+++ b/bench/Benchmark.hs
@@ -92,7 +92,18 @@ main = do
         , bench "gamma,a<1"   $ whnfIO $ loop iter (gamma 0.5 1   mwc :: IO Double)
         , bench "gamma,a>1"   $ whnfIO $ loop iter (gamma 2   1   mwc :: IO Double)
         , bench "chiSquare"   $ whnfIO $ loop iter (chiSquare 4   mwc :: IO Double)
-        , bench "binomial"    $ whnfIO $ loop iter (binomial 1400 0.4 mwc :: IO Int)
+          -- NOTE: We switch between algorithms when Np=10
+        , bgroup "binomial"
+          [ bench (show p ++ " " ++ show n) $ whnfIO $ loop iter (binomial n p mwc)
+          | (n,p) <- [ (2,  0.2), (2,  0.5), (2,  0.8)
+                     , (10, 0.1), (10, 0.9)
+                     , (20, 0.2), (20, 0.8)
+                       --
+                     , (60,   0.2), (60,   0.8)
+                     , (600,  0.2), (600,  0.8)
+                     , (6000, 0.2), (6000, 0.8)
+                     ]
+          ]
         , bench "beta binomial 10" $ whnfIO $ loop iter (betaBinomial 600 400 10 mwc :: IO Int)
         , bench "beta binomial 100" $ whnfIO $ loop iter (betaBinomial 600 400 100 mwc :: IO Int)
         , bench "beta binomial table 10" $ whnfIO $ loop iter (betaBinomialTable 600 400 10 mwc :: IO Int)


### PR DESCRIPTION
This PR improves performance of binomial with 10-50% speedups with larger gains for BINV algorithm. Mostly optimizations were adding strictness and avoiding allocations.


@idontgetoutmuch it seems using larger than 10 threshold would be more efficient but didn't make necessary measurements for picking better one. So I left it as is. I plan to make release once this PR is merged