### PR TITLE
V1: Add an instance for the new SeedGen type class

### DIFF
--- a/mwc-random.cabal
+++ b/mwc-random.cabal
@@ -71,8 +71,10 @@ library
                , primitive      >= 0.6.2
                , random         >= 1.2
                , time
-               , vector         >= 0.7
+               , vector         >= 0.10.12
                , math-functions >= 0.2.1.0
+  if impl(ghc < 9.4)
+    build-depends: data-array-byte
 
   ghc-options: -Wall -funbox-strict-fields -fwarn-tabs
 

--- a/tests/props.hs
+++ b/tests/props.hs
@@ -245,7 +245,7 @@ logProbBinomial n p k
     k'  = fromIntegral k
     nk' = fromIntegral $ n - k
 
-    
+
 cumulativeChi2 :: Int -> Double -> Double
 cumulativeChi2 (fromIntegral -> ndf) x
   | x <= 0    = 0


### PR DESCRIPTION
This is the first potential version, while the second version is in #98 

This version is faster, since it does not have to rely on intermediate list structure and utilizes some of the `vector` unsafe functionality to achieve that. It also requires a newer version of `vecotr`, since it was only in `vector-0.10.12` that constructor for primitive `Vector` was exported.

The down side of this approach is that a seed that is stored on a big endian machine will not read the same on a little endian machine and vise versa. This is not a problem for the approach take n #98 